### PR TITLE
fix: Eval `jieba--current-dir` during the load progression.

### DIFF
--- a/jieba.el
+++ b/jieba.el
@@ -66,7 +66,7 @@
 
 ;;; Utils
 
-(defun jieba--current-dir ()
+(defconst jieba--current-dir
   (let* ((this-file (cond
                      (load-in-progress load-file-name)
                      ((and (boundp 'byte-compile-current-file)
@@ -74,7 +74,12 @@
                       byte-compile-current-file)
                      (t (buffer-file-name))))
          (dir (file-name-directory this-file)))
-    dir))
+    dir)
+  "Directory of jieba.")
+
+(defun jieba--current-dir ()
+  "Return the directory of jieba."
+  jieba--current-dir)
 
 ;;; Backend Access API
 


### PR DESCRIPTION
Lazy evaluation may cause issue when user invoke `jieba-mode` not in jieba directory.

Close #4 